### PR TITLE
Move filed validation to validateField

### DIFF
--- a/lib/createForm.js
+++ b/lib/createForm.js
@@ -40,11 +40,7 @@ export const createForm = config => {
     return allTouched && noErrors;
   });
 
-  function handleChange(event) {
-    const { name: field, value } = event.target;
-
-    updateTouched(field, true);
-
+  function validateField(field, value) {
     if (validationSchema) {
       isValidating.set(true);
       return util
@@ -53,7 +49,6 @@ export const createForm = config => {
         .then(() => util.update(errors, field, ""))
         .catch(err => util.update(errors, field, err.message))
         .finally(() => {
-          updateField(field, value);
           isValidating.set(false);
         });
     }
@@ -64,12 +59,19 @@ export const createForm = config => {
         .then(() => validateFn({ [field]: value }))
         .then(errs => util.update(errors, field, errs[field]))
         .finally(() => {
-          updateField(field, value);
           isValidating.set(false);
-        })
+        });
     }
 
-    updateField(field, value);
+    return Promise.resolve();
+  }
+
+  function handleChange(event) {
+    const { name: field, value } = event.target;
+
+    updateTouched(field, true);
+
+    return validateField(field, value).finally(() => updateField(field, value));
   }
 
   function handleSubmit(ev) {
@@ -151,6 +153,7 @@ export const createForm = config => {
     handleReset,
     updateField,
     updateTouched,
+    validateField,
     state: derived(
       [form, errors, touched, isValid, isValidating, isSubmitting],
       ([$form, $errors, $touched, $isValid, $isValidating, $isSubmitting]) => ({


### PR DESCRIPTION
### Motivation

I have some custom Input. It's accept mask to format value and export value. DOM input element has masked value, but component export already unmasked value.

When I create form, I can't use `handleChange`, because form will store masked value, so I used `bind:value={$form.phone}`. To track touched state I add custom blur event handler, where call `updateTouched`. The last action that I should do to make my form works is validate field value and set errors.

Example of my form: https://codesandbox.io/s/boring-bash-cnv3x

### Solution

I moved code that validate field value to new `validateField` function. Update `handleChange` to call it. Also add `validateField` to return of `createForm`

