### PR TITLE
Update initial values method

### DIFF
--- a/lib/createForm.js
+++ b/lib/createForm.js
@@ -5,13 +5,9 @@ const NO_ERROR = "";
 const IS_TOUCHED = true;
 
 export const createForm = config => {
-  const initialValues = config.initialValues || {};
+  let initialValues = config.initialValues || {};
 
-  if (Object.keys(initialValues).length < 1) {
-    const provided = JSON.stringify(initialValues);
-    console.warn(
-      `createForm requires initialValues to be a non empty object or array, provided ${provided}`
-    );
+  if (!isInitialValuesValid()) {
     return;
   }
 
@@ -19,15 +15,15 @@ export const createForm = config => {
   const validateFn = config.validate;
   const onSubmit = config.onSubmit;
 
-  const initial = {
+  const getInitial = {
     values: () => util.cloneDeep(initialValues),
     errors: () => util.assignDeep(initialValues, NO_ERROR),
     touched: () => util.assignDeep(initialValues, !IS_TOUCHED)
   };
 
-  const form = writable(initial.values());
-  const errors = writable(initial.errors());
-  const touched = writable(initial.touched());
+  const form = writable(getInitial.values());
+  const errors = writable(getInitial.errors());
+  const touched = writable(getInitial.touched());
 
   const isSubmitting = writable(false);
   const isValidating = writable(false);
@@ -132,9 +128,9 @@ export const createForm = config => {
   }
 
   function handleReset() {
-    form.set(initial.values());
-    errors.set(initial.errors());
-    touched.set(initial.touched());
+    form.set(getInitial.values());
+    errors.set(getInitial.errors());
+    touched.set(getInitial.touched());
   }
 
   function clearErrorsAndSubmit(values) {
@@ -158,6 +154,35 @@ export const createForm = config => {
     util.update(touched, field, value);
   }
 
+  function isInitialValuesValid() {
+    if (Object.keys(initialValues).length < 1) {
+      const provided = JSON.stringify(initialValues);
+
+      console.warn(
+        `createForm requires initialValues to be a non empty object or array, provided ${provided}`
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Update the initial values and reset form. Used to dynamically display new form values
+   */
+  function updateInitialValues(newValues, resetForm = true) {
+    if (!isInitialValuesValid()) {
+      return;
+    }
+
+    initialValues = newValues;
+
+    if (resetForm) {
+      handleReset();
+    }
+  }
+
   return {
     form,
     errors,
@@ -172,6 +197,7 @@ export const createForm = config => {
     updateValidateField,
     updateTouched,
     validateField,
+    updateInitialValues,
     state: derived(
       [form, errors, touched, isValid, isValidating, isSubmitting],
       ([$form, $errors, $touched, $isValid, $isValidating, $isSubmitting]) => ({

--- a/lib/createForm.js
+++ b/lib/createForm.js
@@ -171,16 +171,14 @@ export const createForm = config => {
   /**
    * Update the initial values and reset form. Used to dynamically display new form values
    */
-  function updateInitialValues(newValues, resetForm = true) {
+  function updateInitialValues(newValues) {
     if (!isInitialValuesValid()) {
       return;
     }
 
     initialValues = newValues;
 
-    if (resetForm) {
-      handleReset();
-    }
+    handleReset();
   }
 
   return {


### PR DESCRIPTION
Needed a clean way to set new initials when pre-populated forms are used and filled dynamically based on user selection.
Returns a updateInitialValues method that can be used to refresh the values of the form based on user selection.

Open to any change in implementation.

All you have to do it `updateInitialValues({firstName: 'Tom', lastName: 'Smith'})` and the form is reset with new initials, and untouched.
You can pass `updateInitialValues({...}, false)` to not auto reset the form on new initials.