### PR TITLE
Use id identifier as well, instead of only name

### DIFF
--- a/lib/createForm.js
+++ b/lib/createForm.js
@@ -46,7 +46,7 @@ export const createForm = config => {
 
   function handleChange(event) {
     const el = event.target;
-    const field = el.name;
+    const field = el.name || el.id;
     const value = isCheckbox(el) ? el.checked : el.value;
 
     updateTouched(field, true);


### PR DESCRIPTION
Name is technically obsolete in html standards, id should be used instead.
But to maintain backwards compatability (and flexibility in case someone wants name used by svelte-forms-lib and id to be different), appended `|| el.id` in identifier name.