### PR TITLE
Clear errors using the current errors state

### DIFF
--- a/lib/createForm.js
+++ b/lib/createForm.js
@@ -1,4 +1,4 @@
-import { derived, writable } from "svelte/store";
+import { derived, get, writable } from "svelte/store";
 import { util } from "./util";
 
 const NO_ERROR = "";
@@ -120,7 +120,7 @@ export const createForm = config => {
 
   function clearErrorsAndSubmit(values) {
     return Promise.resolve()
-      .then(() => errors.set(util.assignDeep(values, "")))
+      .then(() => errors.set(util.assignDeep(get(errors), "")))
       .then(() => onSubmit(values, form, errors))
       .finally(() => isSubmitting.set(false));
   }


### PR DESCRIPTION
Errors should be reset respecting the validation schema. 
Instead of resetting errors from the values, just reset the current error state.

This is a fix for #26 