### PR TITLE
Store for actual modified state

### DIFF
--- a/lib/createForm.js
+++ b/lib/createForm.js
@@ -36,6 +36,22 @@ export const createForm = config => {
     return allTouched && noErrors;
   });
 
+  const modified = derived(form, $form => {
+    const obj = util.assignDeep($form, false);
+
+    for (let key in $form) {
+      if ($form[key] !== initialValues[key]) {
+        obj[key] = true;
+      }
+    }
+
+    return obj;
+  });
+
+  const isModified = derived(modified, $modified => {
+    return util.getValues($modified).some(field => field === true);
+  });
+
   function isCheckbox(el) {
     return el.getAttribute && el.getAttribute('type') === 'checkbox';
   }
@@ -185,9 +201,11 @@ export const createForm = config => {
     form,
     errors,
     touched,
+    modified,
     isValid,
     isSubmitting,
     isValidating,
+    isModified,
     handleChange,
     handleSubmit,
     handleReset,
@@ -197,14 +215,16 @@ export const createForm = config => {
     validateField,
     updateInitialValues,
     state: derived(
-      [form, errors, touched, isValid, isValidating, isSubmitting],
-      ([$form, $errors, $touched, $isValid, $isValidating, $isSubmitting]) => ({
+      [form, errors, touched, modified, isValid, isValidating, isSubmitting, isModified],
+      ([$form, $errors, $touched, $modified, $isValid, $isValidating, $isSubmitting, $isModified]) => ({
         form: $form,
         errors: $errors,
         touched: $touched,
+        modified: $modified,
         isValid: $isValid,
         isSubmitting: $isSubmitting,
-        isValidating: $isValidating
+        isValidating: $isValidating,
+        isModified: $isModified
       })
     )
   };


### PR DESCRIPTION
I think in many cases (at least in my project), we're tracking actual modified state of the fields to enable/disable a submit button. The flipped switch "touched" doesn't prove useful in this case.

Like this, the library can abstract away this logic instead of implementing in the page logic.