### PR TITLE
Validate field value with yup validateAt

### DIFF
--- a/lib/createForm.js
+++ b/lib/createForm.js
@@ -1,4 +1,4 @@
-import { derived, writable } from "svelte/store";
+import { derived, writable, get } from "svelte/store";
 import { util } from "./util";
 
 const NO_ERROR = "";
@@ -55,9 +55,9 @@ export const createForm = config => {
 
     if (validationSchema) {
       isValidating.set(true);
-      return util
-        .reach(validationSchema, field)
-        .validate(value)
+
+      return validationSchema
+        .validateAt(field, get(form))
         .then(() => util.update(errors, field, ""))
         .catch(err => util.update(errors, field, err.message))
         .finally(() => {
@@ -77,9 +77,9 @@ export const createForm = config => {
   }
 
   function updateValidateField(field, value) {
-    return validateFieldValue(field, value).then(() => {
-      updateField(field, value);
-    });
+    updateField(field, value);
+
+    return validateFieldValue(field, value);
   }
 
 

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -223,10 +223,11 @@ describe("createForm", () => {
           value: invalid
         }
       };
+
       instance
         .handleChange(event)
         .then(() => subscribeOnce(instance.errors))
-        .then(errors => expect(errors.email).toBe("this must be a valid email"))
+        .then(errors => expect(errors.email).toBe("email must be a valid email"))
         .then(done);
     });
 


### PR DESCRIPTION
My attempt to fix #23

yup.ref and you.resolve dont work for single field validation. 
Using Yups [validateAt](https://github.com/jquense/yup#mixedvalidateatpath-string-value-any-options-object-promiseany-validationerror) method allows validation of a deeply nested path within the schema. Similar to how reach works, but uses the resulting schema as the subject for validation.

@kbytesys
@webfrank

Maybe you guys could take a look at this?

