### PR TITLE
IsSubmitting not set to false when using a validation function

### DIFF
--- a/lib/create-form.js
+++ b/lib/create-form.js
@@ -121,11 +121,14 @@ export const createForm = (config) => {
 
         return Promise.resolve()
           .then(() => validateFn(values))
-          .then((error) =>
-            util.isEmpty(error)
-              ? clearErrorsAndSubmit(values)
-              : errors.set(error),
-          )
+          .then((error) => {
+            if (util.isEmpty(error)) {
+              clearErrorsAndSubmit(values);
+            } else {
+              errors.set(error);
+              isSubmitting.set(false);
+            }
+          })
           .finally(() => isValidating.set(false));
       }
 


### PR DESCRIPTION
The bug:

I had a button that I wanted to disable while my form is submitting. If my form validation returns some errors, the button stays disabled.

Steps to reproduce the issue:

1. Create a form with a validation function.
2. Have your validation function return an error for any given field.
3. Call the submit function.
4. Once the validation fails, the `isSubmitting` observable is still true => it should be set to false.

If you use the `validationSchema` option, the value of `isSubmitting` will be OK (see code 2 lines below what I changed).