### PR TITLE
Use Object.entries instead of for…in to iterate over arrays

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -27,9 +27,9 @@ function isEmpty(object) {
 
 function getValues(object) {
   let result = [];
-  for (const key in object) {
+  for (const [, value] of Object.entries(object)) {
     result = result.concat(
-      typeof object[key] === 'object' ? getValues(object[key]) : object[key],
+      typeof value === 'object' ? getValues(value) : value,
     );
   }
   return result;


### PR DESCRIPTION
... because object may be an array and for…in cannot be safely used for arrays.

I ran into a bug in a project I'm working on where `isValid` was incorrectly returning `false`. I tried to reproduce in a sandbox and found that it returned `true` there.

When I dug deeper I found that `getValues($touched)` was returning some extra values here:

```
  const isValid = derived([errors, touched], ([$errors, $touched]) => {
    const allTouched = util
      .getValues($touched)
      .every((field) => field === IS_TOUCHED);
    const noErrors = util
      .getValues($errors)
      .every((field) => field === NO_ERROR);
    return allTouched && noErrors;
  });
```

Looking at those values, they were some functions which were defined on `Array.prototype`. Digging deeper I found that this was due to the `for…in` loop in `getValues`.

Apparently, it is recommended to never use `for…in` to loop over the elements of array (see [here](https://stackoverflow.com/questions/10179815/get-loop-counter-index-using-for-of-syntax-in-javascript/10179849#10179849) and [here](https://stackoverflow.com/questions/4467449/javascript-how-to-remove-prototype-methods-from-a-data-object-or-make-objects-wo/4467585#4467585), for example)).

We could debate whether apps _should_ be adding functions to `Array.prototype`. But regardless of how you feel about that, I think we should fix this library to loop over arrays properly and safely.

`Object.entries()` seems to be a reliable way to iterate over regular objects and arrays (so we don't have to have a branch based on `Array.isArray` like we have in `assignDeep`, for example), so that's the solution I used in this pull request. Let me know if there's a better way though.

This also removes the duplication in the `object[key]` lookups (we were looking it up 3 times in this function).

Here is a sandbox reproducing the bug: https://codesandbox.io/s/competent-thompson-6lcid?file=/App.svelte