### PR TITLE
fix(shape of initial errors)

### DIFF
--- a/lib/create-form.js
+++ b/lib/create-form.js
@@ -21,7 +21,7 @@ export const createForm = (config) => {
 
   const getInitial = {
     values: () => util.cloneDeep(initialValues),
-    errors: () => util.assignDeep(initialValues, NO_ERROR),
+    errors: () => validationSchema ? util.getErrorsFromSchema(validationSchema.fields) : util.assignDeep(initialValues, NO_ERROR),
     touched: () => util.assignDeep(initialValues, !IS_TOUCHED),
   };
 
@@ -167,7 +167,7 @@ export const createForm = (config) => {
 
   function clearErrorsAndSubmit(values) {
     return Promise.resolve()
-      .then(() => errors.set(util.assignDeep(values, '')))
+      .then(() => errors.set(getInitial.errors()))
       .then(() => onSubmit(values, form, errors))
       .finally(() => isSubmitting.set(false));
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -37,11 +37,11 @@ function getValues(object) {
 
 function getErrorsFromSchema(schema, errors = {}) {
   for (const key in schema) {
-    if(schema[key].type === 'object') {
+    if(schema[key].type === 'object' && !isEmpty(schema[key].fields)) {
       errors[key] = getErrorsFromSchema(schema[key].fields, Object.assign({}, errors));
     }
 
-    if(schema[key].type !== 'object') {
+    else {
       errors[key] = '';
     }
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -35,6 +35,20 @@ function getValues(object) {
   return result;
 }
 
+function getErrorsFromSchema(schema, errors = {}) {
+  for (const key in schema) {
+    if(schema[key].type === 'object') {
+      errors[key] = getErrorsFromSchema(schema[key].fields, Object.assign({}, errors));
+    }
+
+    if(schema[key].type !== 'object') {
+      errors[key] = '';
+    }
+  }
+
+  return errors;
+}
+
 function assignDeep(object, value) {
   if (Array.isArray(object)) {
     return object.map((o) => assignDeep(o, value));
@@ -124,6 +138,7 @@ function getIn(schema, path, value, context) {
 }
 
 export const util = {
+  getErrorsFromSchema,
   assignDeep,
   cloneDeep,
   getValues,

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -1,3 +1,4 @@
+/* globals beforeEach, console, describe, expect, it, require, jest */
 const {createForm} = require('../lib');
 const yup = require('yup');
 const Chance = require('chance');
@@ -5,7 +6,7 @@ const Chance = require('chance');
 const chance = new Chance();
 
 function nonEmpty(array) {
-  return array.filter((str) => str !== '');
+  return array.filter((string) => string !== '');
 }
 
 function subscribeOnce(observable) {
@@ -72,11 +73,30 @@ describe('createForm', () => {
       expect(instance.errors.subscribe).toBeDefined();
     });
 
-    it('contains the current values which are accessed by subscription', () => {
+    it('should match the shape of validationSchema', () => {
+      instance = getInstance({
+        initialValues: {
+          name: '',
+          address: {
+            street: '',
+            city: '',
+            country: ''
+          },
+        },
+        validationSchema: yup.object().shape({
+          name: yup.string().required(),
+          address: yup.object().shape({
+            street: yup.string().required(),
+            city: yup.string().required()
+          })
+        })
+      });
+
       subscribeOnce(instance.errors).then((errors) => {
         expect(errors.name).toBe('');
-        expect(errors.email).toBe('');
-        expect(errors.country).toBe('');
+        expect(errors.address.street).toBe('');
+        expect(errors.address.city).toBe('');
+        expect(errors.address.country).not.toBeDefined();
       });
     });
   });


### PR DESCRIPTION
Fix #26

I took a look at Formik and their docs confirmed my thoughts.

"Form validation errors. Should match the shape of your form's values defined in initialValues. If you are using validationSchema (which you should be), keys and shape will match your schema exactly."

The file rename and var renaming was to fix linting errors.

This PR will make #27 redundant