### PR TITLE
fix empty initialValues causing error

### DIFF
--- a/lib/create-form.js
+++ b/lib/create-form.js
@@ -11,10 +11,6 @@ function isCheckbox(element) {
 export const createForm = (config) => {
   let initialValues = config.initialValues || {};
 
-  if (!isInitialValuesValid()) {
-    return;
-  }
-
   const validationSchema = config.validationSchema;
   const validateFn = config.validate;
   const onSubmit = config.onSubmit;
@@ -186,29 +182,10 @@ export const createForm = (config) => {
     util.update(touched, field, value);
   }
 
-  function isInitialValuesValid() {
-    if (Object.keys(initialValues).length === 0) {
-      const provided = JSON.stringify(initialValues);
-
-      // eslint-disable-next-line no-undef
-      console.warn(
-        `createForm requires initialValues to be a non empty object or array, provided ${provided}`,
-      );
-
-      return false;
-    }
-
-    return true;
-  }
-
   /**
    * Update the initial values and reset form. Used to dynamically display new form values
    */
   function updateInitialValues(newValues) {
-    if (!isInitialValuesValid()) {
-      return;
-    }
-
     initialValues = newValues;
 
     handleReset();

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -41,19 +41,6 @@ describe('createForm', () => {
     instance = getInstance();
   });
 
-  describe('config', () => {
-    it('requires initialValues to be provided and not to be empty', () => {
-      const consoleWarn = jest.spyOn(console, 'warn').mockImplementation();
-      const initialValues = {};
-      const config = {initialValues, onSubmit: jest.fn()};
-
-      createForm(config);
-      expect(consoleWarn).toBeCalledWith(
-        'createForm requires initialValues to be a non empty object or array, provided {}',
-      );
-    });
-  });
-
   describe('$form', () => {
     it('returns an observable with a subscribe method', () => {
       expect(instance.form.subscribe).toBeDefined();

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -41,6 +41,15 @@ describe('createForm', () => {
     instance = getInstance();
   });
 
+  describe('config', () => {
+    it('does not throw when no initialValues provided', () => {
+      const initialValues = undefined;
+      const config = { initialValues };
+
+      expect(() => createForm(config)).not.toThrow();
+    });
+  });
+
   describe('$form', () => {
     it('returns an observable with a subscribe method', () => {
       expect(instance.form.subscribe).toBeDefined();


### PR DESCRIPTION
Fixes #71

Removed isInitialValuesValid check. Don't think it made much sense having it, especially since the default value for initialValues is an empty object which doesn't pass the check.

Needed to remove 1 test. Sorry