### PR TITLE
feat: added type definitions and textarea component

### DIFF
--- a/lib/components/Textarea.svelte
+++ b/lib/components/Textarea.svelte
@@ -1,0 +1,12 @@
+<script>
+  import {getContext} from 'svelte';
+  import {key} from './key';
+
+  export let name;
+
+  const {form, handleChange} = getContext(key);
+</script>
+
+<textarea {name} {...$$props} on:change={handleChange} on:blur={handleChange}>
+  {$form[name]}
+</textarea>

--- a/lib/components/Textarea.svelte
+++ b/lib/components/Textarea.svelte
@@ -7,6 +7,6 @@
   const {form, handleChange} = getContext(key);
 </script>
 
-<textarea {name} {...$$props} on:change={handleChange} on:blur={handleChange}>
-  {$form[name]}
-</textarea>
+<!-- There is a weird error when prettier formats this so we ignore it -->
+<!-- prettier-ignore -->
+<textarea {name} {...$$props} on:change={handleChange} on:blur={handleChange}>{$form[name]}</textarea>

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,87 @@
+import type {SvelteComponentTyped} from 'svelte';
+import type {Readable, Writable} from 'svelte/store';
+import type {ObjectSchema} from 'yup';
+
+/** Unfortunately svelte currently does not support generics in components*/
+type FormProps<Inf = Record<string, unknown>> = {
+  class?: string;
+  initialValues: Inf;
+  onSubmit: ((values: Inf) => any) | ((values: Inf) => Promise<any>);
+  validate?: (values: Inf) => any | undefined;
+  validationSchema?: ObjectSchema<any>;
+};
+
+type FieldProps = {
+  name: string;
+  type?: string;
+  value?: string;
+};
+
+type SelectProps = {
+  name: string;
+  class?: string;
+  value?: string;
+};
+
+type ErrorProps = {
+  name: string;
+  class?: string;
+};
+
+declare function createForm<Inf = Record<string, unknown>>(formProps: {
+  initialValues: Inf;
+  onSubmit: (values: Inf) => any | Promise<any>;
+  validate?: (values: Inf) => any | undefined;
+  validationSchema?: ObjectSchema<any>;
+}): {
+  form: Writable<Inf>;
+  errors: Writable<Record<keyof Inf, string>>;
+  touched: Writable<Record<keyof Inf, boolean>>;
+  modified: Readable<Record<keyof Inf, boolean>>;
+  isValid: Readable<boolean>;
+  isSubmitting: Writable<boolean>;
+  isValidating: Writable<boolean>;
+  isModified: Readable<boolean>;
+  updateField: (field: keyof Inf, value: any) => void;
+  updateValidateField: (field: keyof Inf, value: any) => void;
+  updateTouched: (field: keyof Inf, value: any) => void;
+  validateField: (field: keyof Inf) => Promise<any>;
+  updateInitialValues: (newValues: Inf) => void;
+  handleReset: () => void;
+  state: Readable<{
+    form: Inf;
+    errors: Record<keyof Inf, string>;
+    touched: Record<keyof Inf, boolean>;
+    modified: Record<keyof Inf, boolean>;
+    isValid: boolean;
+    isSubmitting: boolean;
+    isValidating: boolean;
+    isModified: boolean;
+  }>;
+  handleChange: () => void;
+  handleSubmit: () => any;
+};
+
+declare class Form extends SvelteComponentTyped<
+  FormProps & {
+    class?: string;
+  },
+  {},
+  {default: any}
+> {}
+
+declare class Field extends SvelteComponentTyped<FieldProps, {}, {}> {}
+
+declare class Select extends SvelteComponentTyped<
+  SelectProps,
+  {},
+  {default: any}
+> {}
+
+declare class ErrorMessage extends SvelteComponentTyped<
+  ErrorProps,
+  {},
+  {default: any}
+> {}
+
+export {createForm, Form, Field, Select, ErrorMessage};

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -28,6 +28,10 @@ type ErrorProps = {
   class?: string;
 };
 
+type TextareaProps = {
+  name: string;
+};
+
 declare function createForm<Inf = Record<string, unknown>>(formProps: {
   initialValues: Inf;
   onSubmit: (values: Inf) => any | Promise<any>;
@@ -72,6 +76,8 @@ declare class Form extends SvelteComponentTyped<
 
 declare class Field extends SvelteComponentTyped<FieldProps, {}, {}> {}
 
+declare class Textarea extends SvelteComponentTyped<TextareaProps, {}, {}> {}
+
 declare class Select extends SvelteComponentTyped<
   SelectProps,
   {},
@@ -84,4 +90,4 @@ declare class ErrorMessage extends SvelteComponentTyped<
   {default: any}
 > {}
 
-export {createForm, Form, Field, Select, ErrorMessage};
+export {createForm, Form, Field, Select, ErrorMessage, Textarea};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 export {createForm} from './create-form';
 export {default as Form} from './components/Form.svelte';
+export {default as Textarea} from './components/Textarea.svelte';
 export {default as Field} from './components/Field.svelte';
 export {default as Select} from './components/Select.svelte';
 export {default as ErrorMessage} from './components/ErrorMessage.svelte';

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "svelte-forms-lib",
   "version": "0.0.0-semantically-released",
   "description": "Svelte forms lib - A lightweight library for managing forms in Svelte v3",
+  "typings": "./lib/index.d.ts",
   "scripts": {
     "start": "rollup -c -w rollup.config.js",
     "build": "cross-env NODE_ENV=production && rollup -c rollup.config.js",


### PR DESCRIPTION
Those are the type definitions for svelte-forms-lib, there might be some optimizations but it's a good starting point.

Svelte currently does not support generics in components, there are some discussions around it but i couldn't find a solution.

Also i have added the textarea helper component as requested here: [#86](https://github.com/tjinauyeung/svelte-forms-lib/issues/86)

fixes [#34](https://github.com/tjinauyeung/svelte-forms-lib/issues/34)
fixes [#81](https://github.com/tjinauyeung/svelte-forms-lib/issues/81)
implements [#86](https://github.com/tjinauyeung/svelte-forms-lib/issues/86)



