### PR TITLE
fix(textarea.svelte): the textarea component had a bug with prettier

### DIFF
--- a/lib/components/Textarea.svelte
+++ b/lib/components/Textarea.svelte
@@ -7,6 +7,5 @@
   const {form, handleChange} = getContext(key);
 </script>
 
-<textarea {name} on:change={handleChange} on:blur={handleChange} {...$$props}>
-  {$form[name]}
-</textarea>
+<!-- prettier-ignore -->
+<textarea {name} on:change={handleChange} on:blur={handleChange} {...$$props}>{$form[name]}</textarea>


### PR DESCRIPTION
The textarea component had a bug with prettier, when you clicked out of it. Randomly applied spaces
and new lines before the text. I don't know why it was happening but the prettier-ignore fixes that issue.

