### PR TITLE
Empty object in errors when field is array type

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -54,13 +54,15 @@ function getErrorsFromSchema(initialValues, schema, errors = {}) {
       case schema[key].type === 'array': {
         const values =
           initialValues && initialValues[key] ? initialValues[key] : [];
-        errors[key] = values.map((value) =>
-          getErrorsFromSchema(
+
+        errors[key] = values.map((value) => {
+          const innerError = getErrorsFromSchema(
             value,
             schema[key].innerType.fields,
             Object.assign({}, errors[key]),
-          ),
-        );
+          );
+          return Object.keys(innerError).length > 0 ? innerError : '';
+        });
         break;
       }
 


### PR DESCRIPTION
With this code example:
```js
const schema = yup.object().shape({
  tags: yup
    .array()
    .of(yup.string())
    .test(
      "all-of-tags-list",
      "Укажите тэги из разрешенного списка",
      (tags) => tags.every((t) => $tagsList.includes(t))
    )
    .optional(),
});

const {errors, form, touched, handleChange, handleSubmit} = createForm({
  initialValues: {
    tags: ["Andorra"],
  },
  validationSchema: schema,
});
```

```html
  <form on:submit={handleSubmit}>
     <TagsInput
            ...
            onChange={handleChange}
            bind:tags={$form.tags}
          />
          {#if $errors["tags"] && $touched["tags"]}
            <span class="text-red">{$errors["tags"]}</span>
          {/if}
  </form>
```
I get issued with this:
![image](https://user-images.githubusercontent.com/23456328/127925222-67545245-b9dd-4383-9b6f-59daacefc514.png)

And during debug I noticed that in switch-case "object" condition returning an array with empty object (`[{}]`) if errors is not occurred inside inner check. 
This PR should fix this error.
