### PR TITLE
Add key to typescript definitions

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  '*.{svelte,js,ts}': ['eslint', 'prettier --write'],
+  '*.{svelte,js}': ['eslint', 'prettier --write'],
 };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -89,4 +89,6 @@ declare class ErrorMessage extends SvelteComponentTyped<
   {default: any}
 > {}
 
-export {createForm, Form, Field, Select, ErrorMessage, Textarea};
+declare const key: {};
+
+export {createForm, key, Form, Field, Select, ErrorMessage, Textarea};


### PR DESCRIPTION
`key` is exported here so updating typescript definitions accordingly - https://github.com/tjinauyeung/svelte-forms-lib/blob/master/lib/index.js#L10

Also omit typescript from being run through eslint as it only can check javascript