### PR TITLE
fix: Do not call `assignDeep` for `null` values.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -84,7 +84,7 @@ function assignDeep(object, value) {
   const copy = {};
   for (const key in object) {
     copy[key] =
-      typeof object[key] === 'object' ? assignDeep(object[key], value) : value;
+      typeof object[key] === 'object' && !isNullish(object[key]) ? assignDeep(object[key], value) : value;
   }
   return copy;
 }


### PR DESCRIPTION
Currently, `assignDeep` function is called for properties with null values because of a bad check, and sets property value to `{}` inside `errors` schema.
The culprit is `typeof` check, since nobody considered that `typeof null` equals to `object`.