### PR TITLE
Check for element before handling change event

### DIFF
--- a/lib/create-form.js
+++ b/lib/create-form.js
@@ -109,10 +109,13 @@ export const createForm = (config) => {
 
   function handleChange(event) {
     const element = event.target;
-    const field = element.name || element.id;
-    const value = resolveValue(element);
 
-    return updateValidateField(field, value);
+    if(element) {
+      const field = element.name || element.id;
+      const value = resolveValue(element);
+
+      return updateValidateField(field, value);
+    }
   }
 
   function handleSubmit(event) {


### PR DESCRIPTION
svelte-forms-lib throw this error message in sveltekit :
TypeError: Cannot read properties of null (reading 'name')

We should check element before handling change event.