### PR TITLE
fix(create-form.js): add return for onSubmit function in handleSubmit

### DIFF
--- a/lib/create-form.js
+++ b/lib/create-form.js
@@ -130,7 +130,7 @@ export const createForm = (config) => {
           .then(() => validateFunction(values))
           .then((error) => {
             if (util.isNullish(error) || util.getValues(error).length === 0) {
-              clearErrorsAndSubmit(values);
+              return clearErrorsAndSubmit(values);
             } else {
               errors.set(error);
               isSubmitting.set(false);
@@ -163,7 +163,7 @@ export const createForm = (config) => {
         );
       }
 
-      clearErrorsAndSubmit(values);
+      return clearErrorsAndSubmit(values);
     });
   }
 

--- a/test/specs/library.spec.js
+++ b/test/specs/library.spec.js
@@ -650,6 +650,52 @@ describe('createForm', () => {
         expect(errors.country).toBe('');
       });
     });
+
+    it('returns a promise that only resolves when onSubmit resolves - without validation', async () => {
+      // Test case created for reproducing a bug where the onSubmit function
+      // would not get "waited" for when calling handleSubmit manually due to a
+      // missing return statement in handleSubmit.
+      const values = [];
+
+      const {handleSubmit} = createForm({
+        onSubmit: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          values.push(1);
+        },
+      });
+
+      const myOtherHandler = async () => {
+        await handleSubmit();
+        values.push(2);
+      };
+
+      await myOtherHandler();
+
+      // This test case failed before fixing the bug, See top of this test case.
+      expect(values).toEqual([1, 2]);
+    });
+
+    it('returns a promise that only resolves when onSubmit resolves - with validation', async () => {
+      // See test case above.
+      const values = [];
+
+      const {handleSubmit} = createForm({
+        validate: () => true, // Dummy validation just to make sure that code path is taken.
+        onSubmit: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          values.push(1);
+        },
+      });
+
+      const myOtherHandler = async () => {
+        await handleSubmit();
+        values.push(2);
+      };
+
+      await myOtherHandler();
+
+      expect(values).toEqual([1, 2]);
+    });
   });
 
   describe('validateField', () => {


### PR DESCRIPTION
This commit fixes and issue where onSubmit runs silently in the background because of a missing
return statement in handleSubmit.

fix #152