### PR TITLE
fix(index.d.ts): update return type on updateValidateField

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -39,7 +39,7 @@ type FormState<Inf = Record<string, any>> = {
   isValidating: Writable<boolean>;
   isModified: Readable<boolean>;
   updateField: (field: keyof Inf, value: any) => void;
-  updateValidateField: (field: keyof Inf, value: any) => void;
+  updateValidateField: (field: keyof Inf, value: any) => Promise<any>;
   updateTouched: (field: keyof Inf, value: any) => void;
   validateField: (field: keyof Inf) => Promise<any>;
   updateInitialValues: (newValues: Inf) => void;


### PR DESCRIPTION
`updateValidateField` returns the result of `validateFieldValue` which returns a Promise

https://github.com/tjinauyeung/svelte-forms-lib/blob/master/lib/create-form.js#L107
https://github.com/tjinauyeung/svelte-forms-lib/blob/master/lib/create-form.js#L75-L100

