### PR TITLE
Reversing order of errors before using .map

### DIFF
--- a/lib/create-form.js
+++ b/lib/create-form.js
@@ -151,7 +151,7 @@ export const createForm = (config) => {
               if (yupErrors && yupErrors.inner) {
                 const updatedErrors = getInitial.errors();
 
-                yupErrors.inner.map((error) =>
+                yupErrors.inner.reverse().map((error) =>
                   util.set(updatedErrors, error.path, error.message),
                 );
 


### PR DESCRIPTION
in function `handleSubmit` errors were being mapped from first to last, last being the only saved one (and shown to the user), which was wrong.
Reversing the array before map() fixes this issue.