### PR TITLE
fix(create-form.js): fix onSubmit rejection being ignored when using validationSchema

### DIFF
--- a/lib/create-form.js
+++ b/lib/create-form.js
@@ -142,12 +142,12 @@ export const createForm = (config) => {
       if (validationSchema) {
         isValidating.set(true);
 
-        return (
-          validationSchema
-            .validate(values, {abortEarly: false})
-            .then(() => clearErrorsAndSubmit(values))
+        return validationSchema
+          .validate(values, {abortEarly: false})
+          .then(
+            () => clearErrorsAndSubmit(values),
             // eslint-disable-next-line unicorn/catch-error-name
-            .catch((yupErrors) => {
+            (yupErrors) => {
               if (yupErrors && yupErrors.inner) {
                 const updatedErrors = getInitial.errors();
 
@@ -158,9 +158,9 @@ export const createForm = (config) => {
                 errors.set(updatedErrors);
               }
               isSubmitting.set(false);
-            })
-            .finally(() => isValidating.set(false))
-        );
+            },
+          )
+          .finally(() => isValidating.set(false));
       }
 
       return clearErrorsAndSubmit(values);

--- a/test/specs/library.spec.js
+++ b/test/specs/library.spec.js
@@ -696,6 +696,18 @@ describe('createForm', () => {
 
       expect(values).toEqual([1, 2]);
     });
+
+    it('should reject if onSubmit rejects', async () => {
+      // Test case created for reproducing a bug where a promise rejection in
+      // the onSubmit function would be silently ignored.
+      const {handleSubmit} = createForm({
+        initialValues: {foo: 'bar'},
+        validationSchema: yup.object().shape({foo: yup.string()}),
+        onSubmit: () => Promise.reject('i could not submit'),
+      });
+
+      await expect(handleSubmit()).rejects.toEqual('i could not submit');
+    });
   });
 
   describe('validateField', () => {


### PR DESCRIPTION
This commit fixes an issue that occurs when using yup validation
schema and an `onSubmit` function that rejects.

In this case, the rejection is completely ignored, because because
`handleSubmit` has a `.catch()` function that assumes the error is from yup.

The fix is to change the `catch` to a `then` and use both the [onFulfilled and
onRejected handlers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then), depending on whether validation failed or not.