### PR TITLE
fix: added missing support for generating errors based on yup lazy schema

### DIFF
--- a/lib/create-form.js
+++ b/lib/create-form.js
@@ -31,10 +31,16 @@ export const createForm = (config) => {
 
   const getInitial = {
     values: () => util.cloneDeep(initialValues),
-    errors: () =>
-      validationSchema
-        ? util.getErrorsFromSchema(initialValues, validationSchema.fields)
-        : util.assignDeep(initialValues, NO_ERROR),
+    errors: () => {
+      if (validationSchema) {
+        const fields =
+          validationSchema.type === 'lazy'
+            ? validationSchema.builder(get(form)).fields
+            : validationSchema.fields;
+        return util.getErrorsFromSchema(initialValues, fields);
+      }
+      return util.assignDeep(initialValues, NO_ERROR);
+    },
     touched: () => util.assignDeep(initialValues, !IS_TOUCHED),
   };
 


### PR DESCRIPTION
There is the case of a lazy validation schema. In that case, fields needed for errors can only be retrieved if schema's `builder` method is called.

Lazy schema definition according to yup:
```ts
interface SchemaLazyDescription {
  type: string;
  label?: string;
  meta: object | undefined;
}
```
See how lazy schemas work in yup API docs: https://github.com/jquense/yup#lazyvalue-any--schema-lazy