### PR TITLE
#180 export form state type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -99,4 +99,4 @@ declare class ErrorMessage extends SvelteComponentTyped<
 
 declare const key: {};
 
-export {createForm, key, Form, Field, Select, ErrorMessage, Textarea};
+export {createForm, key, Form, Field, Select, ErrorMessage, Textarea, type FormState};


### PR DESCRIPTION
I am developing base form components in my project and I want to reuse type to provide form state to component. For example
I have a component called "ControlWrapper" which resposible for display label and validation error and I want to be full type safety, so I want to resuse FormState type from lib. Now I need to copy FromState from lib to my own type file and it is affect runtime typescript perfomance and maintainability

Fix for issue [#180](https://github.com/tjinauyeung/svelte-forms-lib/issues/180)