### PR TITLE
Fix error: no exports conditior for svelte

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
     "lib/*"
   ],
   "svelte": "./lib/index.js",
+  "exports": {
+    ".": {
+        "svelte": "./lib/index.js"
+    }
+  },
   "author": "Tjin Au Yeung",
   "browserslist": [
     "last 1 chrome versions"


### PR DESCRIPTION
<img width="1158" alt="Screenshot 2024-08-10 at 1 17 49 PM" src="https://github.com/user-attachments/assets/406e4e60-e8d6-4a5f-80fd-7e92174b266c">
Fix no exports condition error

Using the svelte field in package.json to point at .svelte source files is deprecated and you must use a svelte [export condition](https://nodejs.org/api/packages.html#conditional-exports). vite-plugin-svelte 3 still resolves it as a fallback, but in a future major release this is going to be removed and without exports condition resolving the library is going to fail.